### PR TITLE
fix: use player resize/fullscreenchange events which are more consistent

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -355,7 +355,7 @@ const vr = function(options) {
     videoEl.style.display = 'none';
 
     // Handle window resizes
-    function onWindowResize() {
+    function onWindowResize(event) {
       const width = player.currentWidth();
       const height = player.currentHeight();
 
@@ -364,7 +364,7 @@ const vr = function(options) {
       camera.updateProjectionMatrix();
     }
 
-    window.addEventListener('resize', onWindowResize, false);
+    player.on(['resize', 'fullscreenchange'], onWindowResize);
     window.addEventListener('vrdisplaypresentchange', onWindowResize, true);
 
     function onVRRequestPresent() {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -364,8 +364,9 @@ const vr = function(options) {
       camera.updateProjectionMatrix();
     }
 
-    player.on(['resize', 'fullscreenchange'], onWindowResize);
+    player.on('fullscreenchange', onWindowResize);
     window.addEventListener('vrdisplaypresentchange', onWindowResize, true);
+    window.addEventListener('resize', onWindowResize, true);
 
     function onVRRequestPresent() {
       manager.enterVRMode_();


### PR DESCRIPTION
Verified on Chrome, Safari, Firefox, Edge, and Android Chrome