### PR TITLE
fix: add a cardboard button for native webvr support

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -456,7 +456,7 @@ class VR extends Plugin {
     if (this.options_.forceCardboard ||
         videojs.browser.IS_ANDROID ||
         videojs.browser.IS_IOS) {
-      this.player_.controlBar.addChild('CardboardButton', {});
+      this.addCardboardButton_();
     }
 
     // if ios remove full screen toggle
@@ -523,6 +523,10 @@ class VR extends Plugin {
           this.log('WebVR supported, VRDisplays found.');
           this.vrDisplay = displays[0];
           this.log(this.vrDisplay);
+
+          if (!this.vrDisplay.isPolyfilled) {
+            this.addCardboardButton_();
+          }
         } else {
           this.triggerError_({code: 'web-vr-no-devices-found', dismiss: false});
         }
@@ -541,6 +545,12 @@ class VR extends Plugin {
 
     this.animate_();
     this.initialized_ = true;
+  }
+
+  addCardboardButton_() {
+    if (!this.player_.getChild('CardboardButton')) {
+      this.player_.controlBar.addChild('CardboardButton', {});
+    }
   }
 
   getVideoEl_() {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -524,6 +524,9 @@ class VR extends Plugin {
           this.vrDisplay = displays[0];
           this.log(this.vrDisplay);
 
+          // Native WebVR Head Mounted Displays (HMDs) like the HTC Vive
+          // also need the cardboard button to enter fully immersive mode
+          // so, we want to add the button if we're not polyfilled.
           if (!this.vrDisplay.isPolyfilled) {
             this.addCardboardButton_();
           }


### PR DESCRIPTION
For example, firefox 55 on win 10 with a Vive.
This addresses #14 as well.