### PR TITLE
Orbit controls configuration

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -483,6 +483,9 @@ class VR extends Plugin {
           this.log('no vr displays found going to use OrbitControls');
           this.controls3d = new OrbitControls(this.camera, this.renderedCanvas);
           this.controls3d.target.set(0, 0, -1);
+          this.controls3d.enableZoom = false;
+          this.controls3d.enablePan = false;
+          this.controls3d.rotateSpeed = -0.5;
         }
         this.animationFrameId_ = this.requestAnimationFrame(this.animate_);
       });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -372,7 +372,7 @@ class VR extends Plugin {
     this.videoTexture.magFilter = THREE.LinearFilter;
     this.videoTexture.format = THREE.RGBFormat;
 
-    this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.DoubleSide });
+    this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.FrontSide });
 
     this.changeProjection_(this.currentProjection_);
 


### PR DESCRIPTION
the orbit controls default configuration is not fit for the current use in the VR viewer : 
- rotation control seems inverted, as we are inside the sphere we control
- rotation control is too fast
- zoom and pan are enabled and if used will disrupt the viewing experience at mininum, eventually leading to getting out of the render sphere

so I added some configuration right after the OrbitControls instance creation

I also set the rendering of the sphere as one sided, rendering on the outside was useless