### PR TITLE
fix: do not show rotate instructions

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,7 +70,9 @@ class VR extends Plugin {
     }
 
     this.polyfill_ = new WebVRPolyfill({
-      TOUCH_PANNER_DISABLED: false
+      TOUCH_PANNER_DISABLED: false,
+      // do not show rotate instructions
+      ROTATE_INSTRUCTIONS_DISABLED: true
     });
 
     this.handleVrDisplayActivate_ = videojs.bind(this, this.handleVrDisplayActivate_);


### PR DESCRIPTION
## Description
On initially going into cardboard mode on a device there would be instructions shown, but these instructions would not actually go away. This PR removes them.

Fixes #73 

## Testing
* The cardboard mode button should still work on
  * [x] iOS Safari
  * [ ] Android Chrome
