### PR TITLE
fix: implement touch pan controls again

### DIFF
--- a/scripts/rollup-replace.js
+++ b/scripts/rollup-replace.js
@@ -4,8 +4,13 @@ import replace from 'rollup-plugin-re';
 const modules = [
   'VRControls',
   'VREffect',
-  'OrbitControls'
+  'OrbitControls',
+  'DeviceOrientationControls'
 ];
+
+const globalReplace = function(str, pattern, replacement) {
+  return str.replace(new RegExp(pattern, 'g'), replacement);
+};
 
 export default function(options) {
   return replace(Object.assign({
@@ -21,10 +26,20 @@ export default function(options) {
           code = code.replace(`THREE.${m} =`, `import * as THREE from 'three';\nvar ${m} =`);
 
           // change references from the global modification to the local variable
-          code = code.replace(new RegExp(`THREE.${m}`, 'g'), m);
+          code = globalReplace(code, `THREE.${m}`, m);
 
           // export that local variable as default from this module
           code += `\nexport default ${m};`;
+
+          // expose private functions so that users can manually use controls
+          // and we can add orientation controls
+          if (m === 'OrbitControls') {
+            code = globalReplace(code, 'function rotateLeft\\(', 'rotateLeft = function(');
+            code = globalReplace(code, 'function rotateUp\\(', 'rotateUp = function(');
+
+            code = globalReplace(code, 'rotateLeft', 'scope.rotateLeft');
+            code = globalReplace(code, 'rotateUp', 'scope.rotateUp');
+          }
         });
         return code;
       }}

--- a/src/orbit-orientation-controls.js
+++ b/src/orbit-orientation-controls.js
@@ -1,0 +1,97 @@
+import * as THREE from 'three';
+import OrbitControls from 'three/examples/js/controls/OrbitControls.js';
+import DeviceOrientationControls from 'three/examples/js/controls/DeviceOrientationControls.js';
+
+/**
+ * Convert a quaternion to an angle
+ *
+ * Taken from https://stackoverflow.com/a/35448946
+ * Thanks P. Ellul
+ */
+function Quat2Angle(x, y, z, w) {
+  const test = x * y + z * w;
+
+  // singularity at north pole
+  if (test > 0.499) {
+    const yaw = 2 * Math.atan2(x, w);
+    const pitch = Math.PI / 2;
+    const roll = 0;
+
+    return new THREE.Vector3(pitch, roll, yaw);
+  }
+
+  // singularity at south pole
+  if (test < -0.499) {
+    const yaw = -2 * Math.atan2(x, w);
+    const pitch = -Math.PI / 2;
+    const roll = 0;
+
+    return new THREE.Vector3(pitch, roll, yaw);
+  }
+
+  const sqx = x * x;
+  const sqy = y * y;
+  const sqz = z * z;
+  const yaw = Math.atan2(2 * y * w - 2 * x * z, 1 - 2 * sqy - 2 * sqz);
+  const pitch = Math.asin(2 * test);
+  const roll = Math.atan2(2 * x * w - 2 * y * z, 1 - 2 * sqx - 2 * sqz);
+
+  return new THREE.Vector3(pitch, roll, yaw);
+}
+
+class OrbitOrientationControls {
+  constructor(options) {
+    this.object = options.camera;
+    this.domElement = options.canvas;
+    this.orbit = new OrbitControls(this.object, this.domElement);
+
+    this.speed = 0.5;
+    this.orbit.target.set(0, 0, -1);
+    this.orbit.enableZoom = false;
+    this.orbit.enablePan = false;
+    this.orbit.rotateSpeed = -this.speed;
+
+    // if orientation is supported
+    if (options.orientation) {
+      this.orientation = new DeviceOrientationControls(this.object);
+    }
+  }
+
+  update() {
+    // orientation updates the camera using quaternions and
+    // orbit updates the camera using angles. They are incompatible
+    // and one update overrides the other. So before
+    // orbit overrides orientation we convert our quaternion changes to
+    // an angle change. Then save the angle into orbit so that
+    // it will take those into account when it updates the camera and overrides
+    // our changes
+    if (this.orientation) {
+      this.orientation.update();
+
+      const quat = this.orientation.object.quaternion;
+      const currentAngle = Quat2Angle(quat.x, quat.y, quat.z, quat.w);
+
+      // we also have to store the last angle since quaternions are b
+      if (typeof this.lastAngle_ === 'undefined') {
+        this.lastAngle_ = currentAngle;
+      }
+
+      this.orbit.rotateLeft((this.lastAngle_.z - currentAngle.z) * (1 + this.speed));
+      this.orbit.rotateUp((this.lastAngle_.y - currentAngle.y) * (1 + this.speed));
+      this.lastAngle_ = currentAngle;
+    }
+
+    this.orbit.update();
+  }
+
+  dispose() {
+    this.orbit.dispose();
+
+    if (this.orientation) {
+      this.orientation.dispose();
+    }
+  }
+
+}
+
+export default OrbitOrientationControls;


### PR DESCRIPTION
## Description
Recently `webvr-polyfill` removed support for the touch panner controls that they used to add to their polyfill vr headset. This PR brings them back. 

## Testing
* Make sure that the latest versions of every browser can move around the video with touch controls or mouse
  * [ ] iOS Safari
  * [ ] Android Chrome
  * [ ] Safari
  * [ ] Chrome 
  * [ ] Firefox
* Make sure that mobile browsers can move around the video by physically moving the phone:
    * [ ] iOS Safari
    * [ ] Android Chrome

