### PR TITLE
fix: ios sizing issue when deactivating vr cardboard display

### DIFF
--- a/src/cardboard-button.js
+++ b/src/cardboard-button.js
@@ -82,7 +82,6 @@ class CardboardButton extends Button {
         this.player_.height(this.oldHeight_);
       }
       this.player_.exitFullWindow();
-      window.dispatchEvent(new window.Event('resize'));
     }
 
     this.active_ = false;


### PR DESCRIPTION
## Description
Proposed solution for #103 

## Specific Changes proposed
 - I believe `resize` event shouldn't be triggered on VR cardboard display deactivation. If this event is triggered, the canvas size needs to be reset to its original width/height manually since webvr-polyfill sets the canvas to 100x101px to address some of the Webkit specific issues. 

