### PR TITLE
Fix/ios preroll

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,14 +94,8 @@ class VR extends Plugin {
 
       this.log('video element recycled for this ad, reseting');
       this.reset();
-      // via the contrib-ads docs playing or contentresumed
-      // can mean that content has started again
-      const reInit = () => {
-        this.off(player, ['playing', 'contentresumed'], reInit);
-        this.init();
-      };
 
-      this.one(player, ['playing', 'contentresumed'], reInit);
+      this.one(player, 'playing', this.init);
     }), 1);
 
     this.on(player, 'loadedmetadata', this.init);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -85,7 +85,7 @@ class VR extends Plugin {
 
     // any time the video element is recycled for ads
     // we have to reset the vr state and re-init after ad
-    this.on(player, 'adstart', () => window.setTimeout(() => {
+    this.on(player, 'adstart', () => player.setTimeout(() => {
       // if the video element was recycled for this ad
       if (!player.ads || !player.ads.videoElementRecycled()) {
         this.log('video element not recycled for this ad, no need to reset');
@@ -255,11 +255,7 @@ class VR extends Plugin {
     }
 
     msgs.forEach((msg) => {
-      if (typeof msg === 'string') {
-        videojs.log('VR: ' + msg);
-      } else {
-        videojs.log('VR: ', msg);
-      }
+      videojs.log('VR: ', msg);
     });
   }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -553,14 +553,17 @@ class VR extends Plugin {
 
     if (this.controls3d) {
       this.controls3d.dispose();
+      this.controls3d = null;
     }
 
     if (this.canvasPlayerControls) {
       this.canvasPlayerControls.dispose();
+      this.canvasPlayerControls = null;
     }
 
     if (this.effect) {
       this.effect.dispose();
+      this.effect = null;
     }
 
     window.removeEventListener('resize', this.handleResize_);
@@ -592,10 +595,6 @@ class VR extends Plugin {
 
     // set the current projection to the default
     this.currentProjection_ = this.defaultProjection_;
-
-    if (this.observer_) {
-      this.observer_.disconnect();
-    }
 
     // reset the ios touch to click workaround
     if (this.iosRevertTouchToClick_) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -258,7 +258,11 @@ class VR extends Plugin {
     }
 
     msgs.forEach((msg) => {
-      videojs.log(msg);
+      if (typeof msg === 'string') {
+        videojs.log('VR: ' + msg);
+      } else {
+        videojs.log('VR: ', msg);
+      }
     });
   }
 
@@ -490,10 +494,10 @@ class VR extends Plugin {
     this.getVideoEl_().style.display = 'none';
 
     if (window.navigator.getVRDisplays) {
-      this.log('VR is supported, getting vr displays');
+      this.log('is supported, getting vr displays');
       window.navigator.getVRDisplays().then((displays) => {
         if (displays.length > 0) {
-          this.log('VR Displays found', displays);
+          this.log('Displays found', displays);
           this.vrDisplay = displays[0];
 
           // Native WebVR Head Mounted Displays (HMDs) like the HTC Vive

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -83,6 +83,24 @@ class VR extends Plugin {
 
     this.setProjection(this.options_.projection);
 
+    // ios does not use a new player for some ads
+    // this causes ads to play in 360 mode. we need
+    // to reset the plugin before the ad
+    // then init again after the ad.
+    if (videojs.browser.IS_IOS) {
+      this.on(player, 'adstart', () => {
+        this.reset();
+        // via the contrib-ads docs playing or contentresumed
+        // can mean that content has started again
+        const reInit = () => {
+          this.off(player, ['playing', 'contentresumed'], reInit);
+          this.init();
+        };
+
+        this.one(player, ['playing', 'contentresumed'], reInit);
+      });
+    }
+
     this.on(player, 'loadedmetadata', this.init);
   }
 


### PR DESCRIPTION
Reset needs to null out variables and dispose, just dispose won't actually reset the plugin.
IOS has a special case for many ad plugins that we have to handle.