### PR TITLE
fix: reset event listeners on window correctly

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -545,10 +545,10 @@ class VR extends Plugin {
       this.effect.dispose();
     }
 
-    window.removeEventListener('resize', this.handleResize_);
-    window.removeEventListener('vrdisplaypresentchange', this.handleResize_);
-    window.removeEventListener('vrdisplayactivate', this.handleVrDisplayActivate_);
-    window.removeEventListener('vrdisplaydeactivate', this.handleVrDisplayDeactivate_);
+    window.removeEventListener('resize', this.handleResize_, true);
+    window.removeEventListener('vrdisplaypresentchange', this.handleResize_, true);
+    window.removeEventListener('vrdisplayactivate', this.handleVrDisplayActivate_, true);
+    window.removeEventListener('vrdisplaydeactivate', this.handleVrDisplayDeactivate_, true);
 
     // re-add the big play button to player
     if (!this.player_.getChild('BigPlayButton')) {


### PR DESCRIPTION
We add these listeners with `true` so we must remove them with `true`, or else nothing will happen.

Reported in #8 

See the docs here:`useCaption` on https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener 