### PR TITLE
Fix JavaScript highlight in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ player.vr().cameraVector;
 ## Accessing THREE.js objects
 The Three.js Scene, renderer, and perspective camera are exposed under the `threeJs` object as the properties `scene`, `renderer`, and `camera` on the `vr` plugin namespace.
 
-```
+```js
 var player = videojs('my-video');
 
 player.vr().camera;


### PR DESCRIPTION
## Description
JavaScript code block syntax are not highlighted
![image](https://user-images.githubusercontent.com/13422799/46427837-14308980-c74b-11e8-984b-1aff7e1656e6.png)


## Specific Changes proposed
Fix README.md JavaScript code block highlight

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
