### PR TITLE
custom event for vr initialization

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -537,6 +537,7 @@ class VR extends Plugin {
     window.addEventListener('vrdisplaydeactivate', this.handleVrDisplayDeactivate_, true);
 
     this.initialized_ = true;
+    this.trigger('initialized');
   }
 
   addCardboardButton_() {


### PR DESCRIPTION
## Description
Trigger an initialization event when the three.js objects are available. It is helpful for someone who wants to add 3D objects in the video.

## Specific Changes proposed
add videojs custom event trigger at the end of `init()` function

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
