### PR TITLE
fix: VR switches to the lowest resolution after loading 1 HLS chunk on HLS 360 video

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -483,8 +483,11 @@ class VR extends Plugin {
 
     this.renderedCanvas = this.renderer.domElement;
     this.renderedCanvas.setAttribute('style', 'width: 100%; height: 100%; position: absolute; top:0;');
-    this.player_.el().insertBefore(this.renderedCanvas, this.player_.el().firstChild);
-    this.getVideoEl_().style.display = 'none';
+
+    const videoEl = this.getVideoEl_();
+
+    this.player_.el().insertBefore(this.renderedCanvas, videoEl.nextSibling);
+    videoEl.style.opacity = '0';
 
     if (window.navigator.getVRDisplays) {
       this.log('is supported, getting vr displays');
@@ -594,7 +597,7 @@ class VR extends Plugin {
     }
 
     // reset the video element style so that it will be displayed
-    this.getVideoEl_().style.display = '';
+    this.getVideoEl_().style.opacity = '';
 
     // set the current projection to the default
     this.currentProjection_ = this.defaultProjection_;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -484,10 +484,11 @@ class VR extends Plugin {
     this.renderedCanvas = this.renderer.domElement;
     this.renderedCanvas.setAttribute('style', 'width: 100%; height: 100%; position: absolute; top:0;');
 
-    const videoEl = this.getVideoEl_();
+    const videoElStyle = this.getVideoEl_().style;
 
-    this.player_.el().insertBefore(this.renderedCanvas, videoEl.nextSibling);
-    videoEl.style.opacity = '0';
+    this.player_.el().insertBefore(this.renderedCanvas, this.player_.el().firstChild);
+    videoElStyle.zIndex = '-1';
+    videoElStyle.opacity = '0';
 
     if (window.navigator.getVRDisplays) {
       this.log('is supported, getting vr displays');
@@ -597,7 +598,10 @@ class VR extends Plugin {
     }
 
     // reset the video element style so that it will be displayed
-    this.getVideoEl_().style.opacity = '';
+    const videoElStyle = this.getVideoEl_().style;
+
+    videoElStyle.zIndex = '';
+    videoElStyle.opacity = '';
 
     // set the current projection to the default
     this.currentProjection_ = this.defaultProjection_;


### PR DESCRIPTION
## Description
The `http-streaming` switches VR video to the lowest resolution available in HLS manifest after loading 1 
 HLS chunk on HLS 360 video.
The problem is related to `http-streaming` and adaptive algorithm. The adaptive login will only work correctly when video tag has a width and height but the VR plugin sets `display: none` on `video` tag element which makes video tag width and height equal to 0.

## Specific Changes proposed
We should use `opacity: 0` instead of `display: none` and insert canvas element after the video tag element to make it clickable.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
