### PR TITLE
Add option for detail level in projection sphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Maintenance Status: Stable
     - [`'360_TB'`](#360_tb)
     - [`'EAC'`](#eac)
     - [`'EAC_LR'`](#eac_lr)
+  - [`sphereDetail`](#spheredetail)
   - [`player.mediainfo.projection`](#playermediainfoprojection)
   - [`debug`](#debug)
   - [`omnitone`](#omnitone)
@@ -230,6 +231,14 @@ Used for Equi-Angular Cubemap videos
 
 #### `'EAC_LR'`
 Used for side-by-side Equi-Angular Cubemap videos
+
+### `sphereDetail`
+
+> type: `number`
+
+This alters the number of segments in the spherical mesh onto which equirectangular
+videos are projected. The default is `32` but in some circumstances you may notice
+artifacts and need to increase this number.
 
 ### `player.mediainfo.projection`
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Used for side-by-side Equi-Angular Cubemap videos
 
 ### `sphereDetail`
 
-> type: `number`
+> type: `number`, default: `32`
 
 This alters the number of segments in the spherical mesh onto which equirectangular
 videos are projected. The default is `32` but in some circumstances you may notice

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,7 +21,8 @@ const defaults = {
   omnitone: false,
   forceCardboard: false,
   omnitoneOptions: {},
-  projection: 'AUTO'
+  projection: 'AUTO',
+  sphereDetail: 32
 };
 
 const errors = {
@@ -126,7 +127,7 @@ class VR extends Plugin {
       }
       return this.changeProjection_('NONE');
     } else if (projection === '360') {
-      this.movieGeometry = new THREE.SphereBufferGeometry(256, 32, 32);
+      this.movieGeometry = new THREE.SphereBufferGeometry(256, this.options_.sphereDetail, this.options_.sphereDetail);
       this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.BackSide });
 
       this.movieScreen = new THREE.Mesh(this.movieGeometry, this.movieMaterial);
@@ -137,7 +138,11 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
     } else if (projection === '360_LR' || projection === '360_TB') {
       // Left eye view
-      let geometry = new THREE.SphereGeometry(256, 32, 32);
+      let geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail
+      );
 
       let uvs = geometry.faceVertexUvs[ 0 ];
 
@@ -163,7 +168,11 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
 
       // Right eye view
-      geometry = new THREE.SphereGeometry(256, 32, 32);
+      geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail
+      );
 
       uvs = geometry.faceVertexUvs[ 0 ];
 
@@ -224,7 +233,13 @@ class VR extends Plugin {
 
       this.scene.add(this.movieScreen);
     } else if (projection === '180') {
-      let geometry = new THREE.SphereGeometry(256, 32, 32, Math.PI, Math.PI);
+      let geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail,
+        Math.PI,
+        Math.PI
+      );
 
       // Left eye view
       geometry.scale(-1, 1, 1);
@@ -247,7 +262,13 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
 
       // Right eye view
-      geometry = new THREE.SphereGeometry(256, 32, 32, Math.PI, Math.PI);
+      geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail,
+        Math.PI,
+        Math.PI
+      );
       geometry.scale(-1, 1, 1);
       uvs = geometry.faceVertexUvs[0];
 


### PR DESCRIPTION
## Description
Currently the lack of detail in the underlying sphere mesh used in
equirectangular projections is very obvious and can cause visual
artifacts (a kind of wobble), especially noticeable at the poles.
See below:
![image](https://user-images.githubusercontent.com/1377367/90521600-a2a52d00-e162-11ea-906e-269455c012c7.png)


## Specific Changes proposed

Allow end user to increase the detail level of the sphere mesh.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
