### PR TITLE
fix small screen issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "videojs-vr",
-  "version": "1.7.2",
+  "name": "videojs-vr-sd",
+  "version": "1.7.3",
   "description": "A plugin to add 360 and VR video support to video.js.",
   "author": {
     "name": "James Broberg",
@@ -40,7 +40,7 @@
     "build:lang": "vjslang --dir dist/lang",
     "clean": "shx rm -rf ./dist ./test/dist && shx mkdir -p ./dist ./test/dist",
     "lint": "vjsstandard",
-    "prepublishOnly": "npm-run-all build-prod && vjsverify --verbose",
+
     "start": "npm-run-all -p server watch",
     "server": "karma start scripts/karma.conf.js --singleRun=false --auto-watch",
     "test": "npm run build-test && karma start scripts/karma.conf.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,7 +22,8 @@ const defaults = {
   omnitone: false,
   forceCardboard: false,
   omnitoneOptions: {},
-  projection: 'AUTO'
+  projection: 'AUTO',
+  sphereDetail: 32
 };
 
 const errors = {
@@ -127,7 +128,7 @@ class VR extends Plugin {
       }
       return this.changeProjection_('NONE');
     } else if (projection === '360') {
-      this.movieGeometry = new THREE.SphereBufferGeometry(256, 32, 32);
+      this.movieGeometry = new THREE.SphereBufferGeometry(256, this.options_.sphereDetail, this.options_.sphereDetail);
       this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.BackSide });
 
       this.movieScreen = new THREE.Mesh(this.movieGeometry, this.movieMaterial);
@@ -138,7 +139,11 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
     } else if (projection === '360_LR' || projection === '360_TB') {
       // Left eye view
-      let geometry = new THREE.SphereGeometry(256, 32, 32);
+      let geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail
+      );
 
       let uvs = geometry.faceVertexUvs[ 0 ];
 
@@ -164,7 +169,11 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
 
       // Right eye view
-      geometry = new THREE.SphereGeometry(256, 32, 32);
+      geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail
+      );
 
       uvs = geometry.faceVertexUvs[ 0 ];
 
@@ -225,7 +234,13 @@ class VR extends Plugin {
 
       this.scene.add(this.movieScreen);
     } else if (projection === '180') {
-      let geometry = new THREE.SphereGeometry(256, 32, 32, Math.PI, Math.PI);
+      let geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail,
+        Math.PI,
+        Math.PI
+      );
 
       // Left eye view
       geometry.scale(-1, 1, 1);
@@ -248,7 +263,13 @@ class VR extends Plugin {
       this.scene.add(this.movieScreen);
 
       // Right eye view
-      geometry = new THREE.SphereGeometry(256, 32, 32, Math.PI, Math.PI);
+      geometry = new THREE.SphereGeometry(
+        256,
+        this.options_.sphereDetail,
+        this.options_.sphereDetail,
+        Math.PI,
+        Math.PI
+      );
       geometry.scale(-1, 1, 1);
       uvs = geometry.faceVertexUvs[0];
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,6 +14,7 @@ import OmnitoneController from './omnitone-controller';
 // import controls so they get regisetered with videojs
 import './cardboard-button';
 import './big-vr-play-button';
+import {doubleSizeForSmallScreen} from './utils';
 
 // Default options for the plugin.
 const defaults = {
@@ -565,8 +566,9 @@ void main() {
   }
 
   handleResize_() {
-    const width = this.player_.currentWidth();
-    const height = this.player_.currentHeight();
+    const size = doubleSizeForSmallScreen();
+    const width = size.width;
+    const height = size.height;
 
     this.effect.setSize(width, height, false);
     this.camera.aspect = width / height;
@@ -653,10 +655,12 @@ void main() {
       }
     };
 
-    this.renderer.setSize(this.player_.currentWidth(), this.player_.currentHeight(), false);
+    const size = doubleSizeForSmallScreen();
+
+    this.renderer.setSize(size.width, size.height, false);
     this.effect = new VREffect(this.renderer);
 
-    this.effect.setSize(this.player_.currentWidth(), this.player_.currentHeight(), false);
+    this.effect.setSize(size.width, size.height, false);
     this.vrDisplay = null;
 
     // Previous timestamps for gamepad updates

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,3 +68,20 @@ export const getInternalProjectionName = function(projection) {
   }
 
 };
+
+// double currentWidth/Height for small screen device, for better quality
+// also need a high sphereDetail like 128 (https://github.com/videojs/videojs-vr/pull/225)
+// this is just a workaround
+export const doubleSizeForSmallScreen = function() {
+  let width = this.player_.currentWidth();
+  let height = this.player_.currentHeight();
+
+  if (this.player_.videoWidth() > this.player_.currentWidth() * 2) {
+    width = this.player_.currentWidth() * 2;
+    height = this.player_.currentHeight() * 2;
+  }
+  return {
+    width,
+    height
+  };
+};


### PR DESCRIPTION
## Description
In small screen, quality is bad. So I double render and effect size to get better quality.
also need #225 

## Specific Changes proposed
1. add doubleSizeForSmallScreen function in utils.js, if currentWidth is small than videoWidth, double currentWidth and currentHeight.
2. change render and effect size in plugin.js init function.
3. change size in plugin.js handleResize_ function

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
