### PR TITLE
Bundle three.js examples in module build

### DIFF
--- a/scripts/rollup-example-resolver.js
+++ b/scripts/rollup-example-resolver.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'example-resolver',
+  resolveId(source) {
+    if (source.startsWith('three/examples/js')) {
+      return {
+        id: require.resolve(source),
+        external: false
+      };
+    }
+
+    return null;
+  },
+}

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -1,13 +1,15 @@
 const generate = require('videojs-generate-rollup-config');
 const replace = require('./rollup-replace');
+const exampleResolver = require('./rollup-example-resolver');
 
 // see https://github.com/videojs/videojs-generate-rollup-config
 // for options
 const options = {
   primedPlugins(defaults) {
-    return Object.assign(defaults, {replace});
+    return Object.assign(defaults, {exampleResolver,replace});
   },
   plugins(defaults) {
+    defaults.module.unshift('exampleResolver')
 
     // add replace just after json for each build
     Object.keys(defaults).forEach((type) => {


### PR DESCRIPTION
## Description

Fixes #188

## Specific Changes proposed

Issue #188 describes an issue where using the module build (`videojs-vr.es.js`) will break with the error `THREE is not defined`.  This is because the three.js example files are not bundled and so module consumers receive the unchanged version when installing three.js from npm.

This PR adds a custom resolver which will resolve the three.js example files and mark them as non-external.  This matches the output from the commonjs  bundle where the examples are part of the output  bundle and thus the changes from rollup replace  are preserved.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
