### PR TITLE
option to disable tooglePlay

### DIFF
--- a/src/canvas-player-controls.js
+++ b/src/canvas-player-controls.js
@@ -10,11 +10,12 @@ import videojs from 'video.js';
  *    show the control bar. Moving around the scene in the canvas should not.
  */
 class CanvasPlayerControls extends videojs.EventTarget {
-  constructor(player, canvas) {
+  constructor(player, canvas, options) {
     super();
 
     this.player = player;
     this.canvas = canvas;
+    this.options = options;
 
     this.onMoveEnd = videojs.bind(this, this.onMoveEnd);
     this.onMoveStart = videojs.bind(this, this.onMoveStart);
@@ -61,7 +62,7 @@ class CanvasPlayerControls extends videojs.EventTarget {
     // if the player does not have a controlbar or
     // the move was a mouse click but not left click do not
     // toggle play.
-    if (!this.player.controls() || (e.type === 'mousedown' && !videojs.dom.isSingleLeftClick(e))) {
+    if (this.options.disableTogglePlay || !this.player.controls() || (e.type === 'mousedown' && !videojs.dom.isSingleLeftClick(e))) {
       this.shouldTogglePlay = false;
       return;
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,7 +21,8 @@ const defaults = {
   omnitone: false,
   forceCardboard: false,
   omnitoneOptions: {},
-  projection: 'AUTO'
+  projection: 'AUTO',
+  disableTogglePlay: false
 };
 
 const errors = {
@@ -706,7 +707,7 @@ void main() {
           }
 
           this.controls3d = new OrbitOrientationContols(options);
-          this.canvasPlayerControls = new CanvasPlayerControls(this.player_, this.renderedCanvas);
+          this.canvasPlayerControls = new CanvasPlayerControls(this.player_, this.renderedCanvas, this.options_);
         }
 
         this.animationFrameId_ = this.requestAnimationFrame(this.animate_);


### PR DESCRIPTION
## Description
Feature to disable the tooglePlay manually.

This functionality is useful in live events so that users cannot stop the live, but still have a controlBar available.

## Specific Changes proposed
The proposed changes includes a new option disableTogglePlay to flag on the initialization of the plugin and then use it in the canvas-player-controls.
