### PR TITLE
Update webvr-polyfill to 0.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "global": "^4.4.0",
     "three": "0.93.0",
     "video.js": "^6 || ^7",
-    "webvr-polyfill": "0.10.6"
+    "webvr-polyfill": "0.10.12"
   },
   "devDependencies": {
     "@videojs/generator-helpers": "~1.2.0",


### PR DESCRIPTION
## Description
Update webvr-polyfill version from 0.10.6 to 0.10.12 in hopes of fixing #240 .

## Specific Changes proposed
Update webvr-polyfill version from 0.10.6 to 0.10.12

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
