### PR TITLE
Customize three.js renderer options

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,7 +23,13 @@ const defaults = {
   omnitoneOptions: {},
   projection: 'AUTO',
   sphereDetail: 32,
-  disableTogglePlay: false
+  disableTogglePlay: false,
+  threeRendererOptions:{
+    devicePixelRatio: window.devicePixelRatio,
+    alpha: false,
+    clearColor: 0xffffff,
+    antialias: true
+  },
 };
 
 const errors = {
@@ -655,12 +661,10 @@ void main() {
     }
 
     this.camera.position.set(0, 0, 0);
-    this.renderer = new THREE.WebGLRenderer({
-      devicePixelRatio: window.devicePixelRatio,
-      alpha: false,
-      clearColor: 0xffffff,
-      antialias: true
-    });
+
+    const rendererOptions =this.options_.threeRendererOptions;
+
+    this.renderer = new THREE.WebGLRenderer(rendererOptions);
 
     const webglContext = this.renderer.getContext('webgl');
     const oldTexImage2D = webglContext.texImage2D;


### PR DESCRIPTION
## Description

When the videojs-vr plugin instantiates a [three.js WebGL Renderer](https://threejs.org/docs/#api/en/renderers/WebGLRenderer), it uses [hardcoded values](https://github.com/videojs/videojs-vr/blob/main/src/plugin.js#L658). This change will allow users to override these defaults. This would be beneficial for performance reasons, such as [disabling antialiasing or tweaking power preference](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2).

## Specific Changes proposed

1. In the `defaults` options object in `plugin.js`, there is now a property called `threeRendererOptions` containing values previously hardcoded.
2. The renderer is now instantiated with `options_.threeRendererOptions` which is a merged result of the default values and those supplied by the user (if any), similar to how Omnitone is set up.
