### PR TITLE
set high performance as default power preference for three.js webgl renderer

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -659,7 +659,8 @@ void main() {
       devicePixelRatio: window.devicePixelRatio,
       alpha: false,
       clearColor: 0xffffff,
-      antialias: true
+      antialias: true,
+      powerPreference: 'high-performance'
     });
 
     const webglContext = this.renderer.getContext('webgl');


### PR DESCRIPTION
## Description
The videojs-vr plugin will instantiate a three.js webgl renderer. This changes the default power preference to be `high-performance` so that devices can take advantage of GPU acceleration.

See WebGLContextAttributes: https://registry.khronos.org/webgl/specs/latest/1.0/#5.2

Related: https://github.com/videojs/videojs-vr/pull/259

## Specific Changes proposed
Change default options for three.js webgl renderer so that it uses power preference: high performance.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
