### PR TITLE
docs: update readme links from .com to .app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VR
 
-https://videojs-vr.netlify.com
+https://videojs-vr.netlify.app
 
 [![Build Status](https://travis-ci.org/videojs/videojs-vr.svg?branch=master)](https://travis-ci.org/videojs/videojs-vr)
 [![Greenkeeper badge](https://badges.greenkeeper.io/videojs/videojs-vr.svg)](https://greenkeeper.io/)


### PR DESCRIPTION
## Description
Netlify updated its default site URLs in 2020, transitioning from site-name.netlify.com to site-name.netlify.app.
(see https://answers.netlify.com/t/changes-coming-to-netlify-site-urls-com-to-app/8918)


In theory, the current demo link should still work via redirection. However, the link https://videojs-vr.netlify.com does not properly redirect to https://videojs-vr.netlify.app.

<img width="1227" alt="videojs-vr-link" src="https://github.com/user-attachments/assets/666a0286-56c8-42ea-9e37-936ec966a156">

## Specific Changes proposed
Updates the demo link in the readme to the correct .app URL to prevent confusion and ensure proper functionality.


## Requirements Checklist
- [x] Docs/guides updated
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
